### PR TITLE
Enable mu cache

### DIFF
--- a/config/delta/rules.js
+++ b/config/delta/rules.js
@@ -25,5 +25,19 @@ export default [
             gracePeriod: 250,
             ignoreFromSelf: false
         }
-    }))
+    })),
+    {
+        match: {
+          subject: { }
+        },
+        callback: {
+          url: "http://resources/.mu/delta",
+          method: "POST"
+        },
+        options: {
+          resourceFormat: "v0.0.1",
+          gracePeriod: 250,
+          ignoreFromSelf: true
+        }
+      }
 ]

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -39,7 +39,7 @@ defmodule Dispatcher do
   end
 
   get "/locations/*path", @any do
-    Proxy.forward conn, path, "http://resources/locations/"
+    Proxy.forward conn, path, "http://cache/locations/"
   end
 
   get "/mandataries/*path", @any do

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -23,19 +23,19 @@ defmodule Dispatcher do
   # RESOURCES
   ###############
   get "/administrative-units/*path", @any do
-    Proxy.forward conn, path, "http://resources/administrative-units/"
+    Proxy.forward conn, path, "http://cache/administrative-units/"
   end
 
   get "/agenda-item-handlings/*path", @any do
-    Proxy.forward conn, path, "http://resources/agenda-item-handlings/"
+    Proxy.forward conn, path, "http://cache/agenda-item-handlings/"
   end
 
   get "/agenda-items/*path", @any do
-    Proxy.forward conn, path, "http://resources/agenda-items/"
+    Proxy.forward conn, path, "http://cache/agenda-items/"
   end
 
   get "/governing-bodies/*path", @any do
-    Proxy.forward conn, path, "http://resources/governing-bodies/"
+    Proxy.forward conn, path, "http://cache/governing-bodies/"
   end
 
   get "/locations/*path", @any do
@@ -43,19 +43,19 @@ defmodule Dispatcher do
   end
 
   get "/mandataries/*path", @any do
-    Proxy.forward conn, path, "http://resources/mandataries/"
+    Proxy.forward conn, path, "http://cache/mandataries/"
   end
 
   get "/resolutions/*path", @any do
-    Proxy.forward conn, path, "http://resources/resolutions/"
+    Proxy.forward conn, path, "http://cache/resolutions/"
   end
 
   get "/sessions/*path", @any do
-    Proxy.forward conn, path, "http://resources/sessions/"
+    Proxy.forward conn, path, "http://cache/sessions/"
   end
 
   get "/votes/*path", @any do
-    Proxy.forward conn, path, "http://resources/votes/"
+    Proxy.forward conn, path, "http://cache/votes/"
   end
 
   ###############

--- a/config/resources/domain.lisp
+++ b/config/resources/domain.lisp
@@ -1,7 +1,10 @@
 (in-package :mu-cl-resources)
 
+;; https://github.com/mu-semtech/mu-cl-resources/blob/master/README.md#external-cache
+(defparameter *cache-model-properties* t)
+(defparameter *supply-cache-headers-p* t)
+
 (read-domain-file "besluit-domain-en.lisp")
 (read-domain-file "mandaat-domain-en.lisp")
 
 (setf *fetch-all-types-in-construct-queries* t)
-

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -9,9 +9,11 @@ services:
     restart: "no"
   frontend:
     entrypoint: "echo 'service disabled'"
-  database:
+  cache:
     restart: "no"
   resources:
+    restart: "no"
+  database:
     restart: "no"
   triplestore:
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,8 @@ services:
     logging: *default-logging
   resources:
     image: semtech/mu-cl-resources:feature-optionally-accept-strange-resource-types
+    environment:
+        CACHE_CLEAR_PATH: "http://cache/.mu/clear-keys"
     links:
       - database:database
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,22 @@ services:
     logging: *default-logging
     labels:
       - "logging=true"
+  cache:
+    image: semtech/mu-cache:2.0.2
+    links:
+      - resources:backend
+    labels:
+      - "logging=true"
+    restart: always
+    logging: *default-logging
+  resources:
+    image: semtech/mu-cl-resources:feature-optionally-accept-strange-resource-types
+    links:
+      - database:database
+    volumes:
+      - ./config/resources:/config
+    labels:
+      - "logging=true"
   database:
     image: semtech/mu-authorization:0.6.0-beta.8
     environment:
@@ -38,14 +54,6 @@ services:
       ERROR_ON_UNWRITTEN_DATA: "on"
     volumes:
       - ./config/authorization:/config
-    labels:
-      - "logging=true"
-  resources:
-    image: semtech/mu-cl-resources:feature-optionally-accept-strange-resource-types
-    links:
-      - database:database
-    volumes:
-      - ./config/resources:/config
     labels:
       - "logging=true"
   triplestore:


### PR DESCRIPTION
- Enable cache on all resources

## Benchmark on locations

### Single call

`curl 'https://burgernabije-besluitendatabank-dev.s.redhost.be/locations?filter[niveau]=Gemeente&page[size]=600' -H 'Accept: application/vnd.api+json' -H 'Accept-Encoding: gzip,deflate' --w 'http_code:%{http_code} size_download:%{size_download} time_pretransfer:%{time_pretransfer} time_total:%{time_total}\n'`

#### Initial values

```
http_code:200 size_download:1858 time_pretransfer:0.133594 time_total:0.834886
```

#### With mu-cache enabled

```
http_code:200 size_download:1053 time_pretransfer:0.146390 time_total:0.189866
```

### Multiple calls

`h2load -n 100 -c 40 -H 'Accept: application/vnd.api+json' 'https://burgernabije-besluitendatabank-dev.s.redhost.be/locations?filter%5Bniveau%5D=Gemeente&page%5Bsize%5D=600'`

#### Initial values

```
finished in 5.78s, 17.31 req/s, 3.00MB/s
requests: 100 total, 100 started, 100 done, 100 succeeded, 0 failed, 0 errored, 0 timeout
status codes: 100 2xx, 0 3xx, 0 4xx, 0 5xx
traffic: 17.35MB (18189098) total, 47.10KB (48233) headers (space savings 23.20%), 17.26MB (18096200) data
                     min         max         mean         sd        +/- sd
time for request:   676.90ms       3.65s       1.87s    595.36ms    69.00%
time for connect:    80.77ms    136.37ms    110.27ms     16.00ms    62.50%
time to 1st byte:      1.93s       3.64s       2.36s    316.89ms    77.50%
req/s           :       0.43        0.62        0.52        0.06    60.00%
```

#### With mu-cache enabled

```
finished in 709.03ms, 141.04 req/s, 24.46MB/s
requests: 100 total, 100 started, 100 done, 100 succeeded, 0 failed, 0 errored, 0 timeout
status codes: 100 2xx, 0 3xx, 0 4xx, 0 5xx
traffic: 17.35MB (18188213) total, 46.72KB (47845) headers (space savings 24.30%), 17.26MB (18096000) data
                     min         max         mean         sd        +/- sd
time for request:    83.35ms    294.82ms    178.89ms     50.23ms    54.00%
time for connect:    78.25ms    129.18ms    103.48ms     15.32ms    57.50%
time to 1st byte:   119.89ms    184.55ms    153.14ms     20.04ms    55.00%
req/s           :       3.00        6.26        4.58        0.92    62.50%
```