### PR TITLE
changed sameAs predicate to wasDerivedFrom

### DIFF
--- a/config/resources/besluit-domain-en.lisp
+++ b/config/resources/besluit-domain-en.lisp
@@ -28,7 +28,7 @@
                 (:public :boolean ,(s-prefix "besluit:openbaar"))
                 (:title :string ,(s-prefix "dct:title"))
                 (:type :uri-set ,(s-prefix "besluit:Agendapunt.type"))
-                (:alternate-link :int ,(s-prefix "owl:sameAs"))
+                (:alternate-link :string ,(s-prefix "prov:wasDerivedFrom"))
                 )
   :has-one `((agenda-item :via ,(s-prefix "besluit:aangebrachtNa")
                           :as "added-after")


### PR DESCRIPTION
Changed the predicate in config/resources/besluit-domain-en.lisp from sameAs to wasDerivedFrom. 
As this data is better available.
