### PR TITLE
Added setup script

### DIFF
--- a/docker-compose.override.example.yml
+++ b/docker-compose.override.example.yml
@@ -1,0 +1,32 @@
+version: '3.7'
+
+services:
+  identifier:
+    labels:
+      - "logging=true"
+  uuid-generation:
+    environment:
+      RUN_CRON_JOBS: "true"
+      CRON_FREQUENCY: "0 * * * *"
+    labels:
+      - "logging=true"
+      
+  mandatendatabank-consumer:
+    environment:
+      DCR_DISABLE_DELTA_INGEST: "false" # uncomment to enable data ingestion
+      DCR_DISABLE_INITIAL_SYNC: "false" # uncomment to enable initial sync
+      DCR_SYNC_BASE_URL: "MANDATENDATABANK_URL"
+
+  op-public-consumer:
+    environment:
+      DCR_DISABLE_DELTA_INGEST: "false" # uncomment to enable data ingestion
+      DCR_DISABLE_INITIAL_SYNC: "false" # uncomment to enable initial sync
+      DCR_SYNC_BASE_URL: "OP_PUBLIC_URL"
+
+  besluiten-consumer:
+    environment:
+      DCR_DISABLE_DELTA_INGEST: "false" # uncomment to enable data ingestion
+      DCR_DISABLE_INITIAL_SYNC: "false" # uncomment to enable initial sync
+      BYPASS_MU_AUTH_FOR_EXPENSIVE_QUERIES: 'true' # mu-auth gets stuck on some large string triples
+      DCR_SYNC_BASE_URL: "BESLUITEN_URL"
+ 

--- a/setup.sh
+++ b/setup.sh
@@ -9,12 +9,14 @@ else
   drc="docker compose "
 fi
 
-
-echo "Cloning repository..."
-git clone https://github.com/lblod/app-burgernabije-besluitendatabank.git
-echo "Moving into folder..."
-cd app-burgernabije-besluitendatabank
-
+if test -f "docker-compose.yml"; then
+    echo "Found local installation, continuing..."
+else
+  echo "Cloning repository..."
+  git clone https://github.com/lblod/app-burgernabije-besluitendatabank.git
+  echo "Moving into folder..."
+  cd app-burgernabije-besluitendatabank
+fi
 
 echo "Running initial sync..."
 cp docker-compose.override.example.yml docker-compose.override.yml
@@ -57,7 +59,6 @@ do
     esac
 done
 
-echo $MANDATENDATABANK_URL
 
 sed -i "s/MANDATENDATABANK_URL/${MANDATENDATABANK_URL//\//\\/}/" docker-compose.override.yml
 sed -i "s/OP_PUBLIC_URL/${OP_PUBLIC_URL//\//\\/}/g" docker-compose.override.yml
@@ -67,21 +68,17 @@ sed -i "s/BESLUITEN_URL/${BESLUITEN_URL//\//\\/}/g" docker-compose.override.yml
 read -p "Enable plausible analytics? [y/N]: " enableplausible
 if [[ $enableplausible =~ ^[Yy] ]]
 then
-echo "Configuring plausible analytics..."
-read -p "Plausible API host: " EMBER_PLAUSIBLE_APIHOST
-read -p "Plausible domain: " EMBER_PLAUSIBLE_DOMAIN
+  echo "Configuring plausible analytics..."
+  read -p "Plausible API host: " EMBER_PLAUSIBLE_APIHOST
+  read -p "Plausible domain: " EMBER_PLAUSIBLE_DOMAIN
 
 
 
 
-sed -i "s/services:/services:\n  frontend:\n    environment:\n      EMBER_PLAUSIBLE_APIHOST: \"$EMBER_PLAUSIBLE_APIHOST\"\n      EMBER_PLAUSIBLE_DOMAIN: \"$EMBER_PLAUSIBLE_DOMAIN\"\n/" docker-compose.override.yml
-
-
+  sed -i "s/services:/services:\n  frontend:\n    environment:\n      EMBER_PLAUSIBLE_APIHOST: \"$EMBER_PLAUSIBLE_APIHOST\"\n      EMBER_PLAUSIBLE_DOMAIN: \"$EMBER_PLAUSIBLE_DOMAIN\"\n/" docker-compose.override.yml
 fi
 
 
-
 echo "Running app-burgernabije-besluitendatabank..."
-$drc -f docker-compose.yml -f docker-compose.override.yml -f docker-compose.dev.yml up
+$drc -f docker-compose.yml -f docker-compose.override.yml
 
-echo 

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+clear
+
+echo "Determining docker compose command..."
+if ! type "docker compose" > /dev/null; then
+  # install foobar here
+  drc="docker-compose "
+else
+  drc="docker compose "
+fi
+
+
+echo "Cloning repository..."
+git clone https://github.com/lblod/app-burgernabije-besluitendatabank.git
+echo "Moving into folder..."
+cd app-burgernabije-besluitendatabank
+
+
+echo "Running initial sync..."
+cp docker-compose.override.example.yml docker-compose.override.yml
+sed -i 's/DCR_DISABLE_DELTA_INGEST: "false"/DCR_DISABLE_DELTA_INGEST: "true"/g' docker-compose.override.yml
+sed -i 's/DCR_DISABLE_INITIAL_SYNC: "false"/DCR_DISABLE_INITIAL_SYNC: "true"/g' docker-compose.override.yml
+
+$drc -f docker-compose.yml -f docker-compose.override.yml up | grep -m 1 "All migrations executed"
+
+echo "Finished initial sync, enabling consumers..."
+sed -i 's/DCR_DISABLE_DELTA_INGEST: "true"/DCR_DISABLE_DELTA_INGEST: "false"/g' docker-compose.override.yml
+sed -i 's/DCR_DISABLE_INITIAL_SYNC: "true"/DCR_DISABLE_INITIAL_SYNC: "false"/g' docker-compose.override.yml
+
+
+echo "Select environment setup"
+select SOURCE in "dev" "qa" "prod"
+do
+    BESLUITEN_URL=""
+    MANDATENDATABANK_URL=""
+    OP_PUBLIC_URL=""
+
+    case $SOURCE in
+    "dev")
+        BESLUITEN_URL="https://dev.harvesting-self-service.lblod.info/"
+        MANDATENDATABANK_URL="https://dev.loket.lblod.info/"
+        OP_PUBLIC_URL="https://dev.organisaties.abb.lblod.info/"
+        break
+        ;;
+    "qa")
+        BESLUITEN_URL="https://qa.harvesting-self-service.lblod.info/"
+        MANDATENDATABANK_URL="https://loket.lblod.info/"
+        OP_PUBLIC_URL="https://organisaties.abb.lblod.info/"
+        break
+        ;;
+    "prod")
+        BESLUITEN_URL=""
+        MANDATENDATABANK_URL="https://loket.lokaalbestuur.vlaanderen.be/"
+        OP_PUBLIC_URL="https://organisaties.abb.vlaanderen.be/"
+        break
+        ;;
+    esac
+done
+
+echo $MANDATENDATABANK_URL
+
+sed -i "s/MANDATENDATABANK_URL/${MANDATENDATABANK_URL//\//\\/}/" docker-compose.override.yml
+sed -i "s/OP_PUBLIC_URL/${OP_PUBLIC_URL//\//\\/}/g" docker-compose.override.yml
+sed -i "s/BESLUITEN_URL/${BESLUITEN_URL//\//\\/}/g" docker-compose.override.yml
+
+
+read -p "Enable plausible analytics? [y/N]: " enableplausible
+if [[ $enableplausible =~ ^[Yy] ]]
+then
+echo "Configuring plausible analytics..."
+read -p "Plausible API host: " EMBER_PLAUSIBLE_APIHOST
+read -p "Plausible domain: " EMBER_PLAUSIBLE_DOMAIN
+
+
+
+
+sed -i "s/services:/services:\n  frontend:\n    environment:\n      EMBER_PLAUSIBLE_APIHOST: \"$EMBER_PLAUSIBLE_APIHOST\"\n      EMBER_PLAUSIBLE_DOMAIN: \"$EMBER_PLAUSIBLE_DOMAIN\"\n/" docker-compose.override.yml
+
+
+fi
+
+
+
+echo "Running app-burgernabije-besluitendatabank..."
+$drc -f docker-compose.yml -f docker-compose.override.yml -f docker-compose.dev.yml up
+
+echo 


### PR DESCRIPTION
The script handles the following things either interactively or automatically:
- Cloning the repository
- Disabling consumers & running the initial migrations
- Re-enabling consumers
- Selecting endpoints
- Optionally adding plausible analytics

If wanted, a similar script could be made to allow flushing to be more convenient