### PR TITLE
Fix: unexpose SPARQL endpoint

### DIFF
--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -69,9 +69,6 @@ defmodule Dispatcher do
   ###############
   # SERVICES
   ###############
-  post "/sparql/*path", @json do
-    forward conn, path, "http://triplestore:8890/sparql/"
-  end
 
   # to generate uuids manually
   match "/uuid-generation/run/*path", @json do


### PR DESCRIPTION
The sparql endpoint should likely not be exposed in BNB at this point.
If it should, then mu-identifier should be bumped and mu-authorization
should be exposed instead.