### PR TITLE
added new attributes to agenda items in search config

### DIFF
--- a/config/search/config.json
+++ b/config/search/config.json
@@ -69,16 +69,43 @@
           "http://data.vlaanderen.be/ns/besluit#werkingsgebied",
           "http://www.w3.org/2000/01/rdf-schema#label"
         ],
+        "administrative_unit_name": [
+          "^http://data.vlaanderen.be/ns/besluit#behandelt",
+          "http://data.vlaanderen.be/ns/besluit#isGehoudenDoor",
+          "http://data.vlaanderen.be/ns/besluit#bestuurt",
+          "http://www.w3.org/2000/01/rdf-schema#label"
+        ],
+        "administrative_unit_id": [
+          "^http://data.vlaanderen.be/ns/besluit#behandelt",
+          "http://data.vlaanderen.be/ns/besluit#isGehoudenDoor",
+          "http://data.vlaanderen.be/ns/besluit#bestuurt",
+          "http://mu.semte.ch/vocabularies/core/uuid"
+        ],
+        "abstract_governing_body_id": [
+          "^http://data.vlaanderen.be/ns/besluit#behandelt",
+          "http://data.vlaanderen.be/ns/besluit#isGehoudenDoor",
+          "http://data.vlaanderen.be/ns/mandaat#isTijdspecialisatieVan",
+          "http://mu.semte.ch/vocabularies/core/uuid"
+        ],
         "abstract_governing_body_name": [
           "^http://data.vlaanderen.be/ns/besluit#behandelt",
           "http://data.vlaanderen.be/ns/besluit#isGehoudenDoor",
           "http://data.vlaanderen.be/ns/mandaat#isTijdspecialisatieVan",
           "http://www.w3.org/2004/02/skos/core#prefLabel"
         ],
+        "governing_body_id": [
+          "^http://data.vlaanderen.be/ns/besluit#behandelt",
+          "http://data.vlaanderen.be/ns/besluit#isGehoudenDoor",
+          "http://mu.semte.ch/vocabularies/core/uuid"
+        ],
         "governing_body_name": [
           "^http://data.vlaanderen.be/ns/besluit#behandelt",
           "http://data.vlaanderen.be/ns/besluit#isGehoudenDoor",
           "http://www.w3.org/2004/02/skos/core#prefLabel"
+        ],
+        "session_id": [
+          "^http://data.vlaanderen.be/ns/besluit#behandelt",
+          "http://mu.semte.ch/vocabularies/core/uuid"
         ],
         "session_planned_start": [
           "^http://data.vlaanderen.be/ns/besluit#behandelt",
@@ -92,12 +119,8 @@
           "^http://data.vlaanderen.be/ns/besluit#behandelt",
           "http://www.w3.org/ns/prov#endedAtTime"
         ],
-        "title": [
-          "http://purl.org/dc/terms/title"
-        ],
-        "description": [
-          "http://purl.org/dc/terms/description"
-        ]
+        "title": ["http://purl.org/dc/terms/title"],
+        "description": ["http://purl.org/dc/terms/description"]
       },
       "mappings": {
         "properties": {


### PR DESCRIPTION
In order to filter on administrative unit and governing body. We need to add the IDs of these entities to the attributes of agenda items.
Previously only the label was available, which is not sufficient for filtering.

