### PR TITLE
switch off keeping delta files for besluiten-consumer

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -199,7 +199,7 @@ services:
       DCR_INITIAL_SYNC_JOB_OPERATION: "http://redpencil.data.gift/id/jobs/concept/JobOperation/deltas/consumer/initialSync/besluiten"
       DCR_DELTA_SYNC_JOB_OPERATION: "http://redpencil.data.gift/id/jobs/concept/JobOperation/deltas/consumer/besluitenSyncing"
       DCR_JOB_CREATOR_URI: "http://data.lblod.info/services/id/besluiten-consumer"
-      DCR_KEEP_DELTA_FILES: "true"
+      DCR_KEEP_DELTA_FILES: "false"
       DCR_DELTA_FILE_FOLDER: "/consumer-files"
       DCR_DISABLE_DELTA_INGEST: "true" # toggle this in override, leave 'true' in default docker-compose.yml
       DCR_DISABLE_INITIAL_SYNC: "true" # toggle this in override, leave 'true' in default docker-compose.yml


### PR DESCRIPTION
there's little value in a production setup in keeping these files and they consume a lot of space:
```
$du -hs consumer-files/
138G	consumer-files/
```