### PR TITLE
feat: add inverse relation on gov classification code

### DIFF
--- a/config/resources/besluit-domain-en.lisp
+++ b/config/resources/besluit-domain-en.lisp
@@ -110,6 +110,9 @@
 (define-resource governing-body-classification-code ()
   :class (s-prefix "ext:BestuursorgaanClassificatieCode")
   :properties `((:label :string ,(s-prefix "skos:prefLabel")))
+  :has-many `((governing-body :via ,(s-prefix "besluit:classificatie")
+                              :inverse t
+                              :as "governing-bodies"))
   :resource-base (s-url "http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/")
   :features '(include-uri)
   :on-path "governing-body-classification-codes")


### PR DESCRIPTION
## Description

So we can fetch the classification codes for the given governing bodies

## How to test

1. This is added directly on the server already!
2. Togheter with the deployed frontend you should be able to fetch all the classifications for the gov-bodies


## Other PR's

- https://github.com/lblod/frontend-lokaal-beslist-mijn-burgerprofiel/pull/35